### PR TITLE
Add compatibility layer for mods accessing spawning logic

### DIFF
--- a/src/main/java/com/ishland/vmp/common/general/spawn_density_cap/SpawnDensityCapperDensityCapDelegate.java
+++ b/src/main/java/com/ishland/vmp/common/general/spawn_density_cap/SpawnDensityCapperDensityCapDelegate.java
@@ -1,0 +1,57 @@
+package com.ishland.vmp.common.general.spawn_density_cap;
+
+import it.unimi.dsi.fastutil.objects.AbstractObject2IntMap;
+import it.unimi.dsi.fastutil.objects.AbstractObjectIterator;
+import it.unimi.dsi.fastutil.objects.AbstractObjectSet;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import net.minecraft.entity.SpawnGroup;
+
+public class SpawnDensityCapperDensityCapDelegate {
+
+    public static Object2IntMap<SpawnGroup> delegateSpawnGroupDensities(int[] spawnGroupDensities) {
+        return new AbstractObject2IntMap<>() {
+            @Override
+            public int size() {
+                return spawnGroupDensities.length;
+            }
+
+            @Override
+            public ObjectSet<Entry<SpawnGroup>> object2IntEntrySet() {
+                return new AbstractObjectSet<>() {
+                    @Override
+                    public ObjectIterator<Entry<SpawnGroup>> iterator() {
+                        return new AbstractObjectIterator<>() {
+                            private int index = 0;
+
+                            @Override
+                            public boolean hasNext() {
+                                return index < spawnGroupDensities.length;
+                            }
+
+                            @Override
+                            public Entry<SpawnGroup> next() {
+                                final int index = this.index;
+                                this.index++;
+                                return new AbstractObject2IntMap.BasicEntry<>(
+                                        SpawnGroup.values()[index], spawnGroupDensities[index]);
+                            }
+                        };
+                    }
+
+                    @Override
+                    public int size() {
+                        return spawnGroupDensities.length;
+                    }
+                };
+            }
+
+            @Override
+            public int getInt(Object key) {
+                return spawnGroupDensities[((SpawnGroup) key).ordinal()];
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/ishland/vmp/mixins/general/spawn_density_cap/MixinSpawnDensityCapperDensityCap.java
+++ b/src/main/java/com/ishland/vmp/mixins/general/spawn_density_cap/MixinSpawnDensityCapperDensityCap.java
@@ -1,13 +1,28 @@
 package com.ishland.vmp.mixins.general.spawn_density_cap;
 
+import com.ishland.vmp.common.general.spawn_density_cap.SpawnDensityCapperDensityCapDelegate;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.entity.SpawnGroup;
 import net.minecraft.world.SpawnDensityCapper;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(SpawnDensityCapper.DensityCap.class)
 public class MixinSpawnDensityCapperDensityCap {
+    @Mutable
+    @Shadow @Final private Object2IntMap<SpawnGroup> spawnGroupsToDensity;
     private final int[] spawnGroupDensities = new int[SpawnGroup.values().length];
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onInit(CallbackInfo ci) {
+        this.spawnGroupsToDensity = SpawnDensityCapperDensityCapDelegate.delegateSpawnGroupDensities(spawnGroupDensities);
+    }
 
     /**
      * @author ishland


### PR DESCRIPTION
This allows mods to access some internal data of spawning logic correctly to improve mod compatibility. 