### PR TITLE
fix: use correct chebyshev calculation in AreaMap

### DIFF
--- a/src/main/java/com/ishland/vmp/common/maps/AreaMap.java
+++ b/src/main/java/com/ishland/vmp/common/maps/AreaMap.java
@@ -233,7 +233,7 @@ public class AreaMap<T> {
     }
 
     private static int chebyshevDistance(int x0, int z0, int x1, int z1) {
-        return Math.min(Math.abs(x0 - x1), Math.abs(z0 - z1));
+        return Math.max(Math.abs(x0 - x1), Math.abs(z0 - z1));
     }
 
     // only for debugging


### PR DESCRIPTION
The `chebyshevDistance` method in the `AreaMap` class seems to be wrong:
https://github.com/RelativityMC/VMP-fabric/blob/bee4c7882ff7faa698e241092c4995b50f7517f7/src/main/java/com/ishland/vmp/common/maps/AreaMap.java#L236

The current implementation uses `Math.min` instead of `Math.max`, even though there are other places in the code where `Math.max` _is_ used instead:
https://github.com/RelativityMC/VMP-fabric/blob/bee4c7882ff7faa698e241092c4995b50f7517f7/src/main/java/com/ishland/vmp/mixins/playerwatching/MixinThreadedAnvilChunkStorage.java#L100

If this was correct I'd love to hear why, if not here's the tiny PR to fix it :)
