### PR TITLE
fix: chunk unload bug present in vanilla

### DIFF
--- a/src/main/java/com/ishland/vmp/mixins/playerwatching/MixinThreadedAnvilChunkStorage.java
+++ b/src/main/java/com/ishland/vmp/mixins/playerwatching/MixinThreadedAnvilChunkStorage.java
@@ -172,8 +172,10 @@ public abstract class MixinThreadedAnvilChunkStorage implements TACSExtension {
 
     @Inject(method = "updatePosition", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerChunkLoadingManager;updateWatchedSection(Lnet/minecraft/server/network/ServerPlayerEntity;)V"))
     private void onPlayerSectionChange(ServerPlayerEntity player, CallbackInfo ci) {
-        this.vmp$updateWatchedSection(player);
+        this.updateWatchedSection(player);
+        player.setChunkFilter(ChunkFilter.cylindrical(player.getWatchedSection().toChunkPos(), this.getViewDistance(player)));
         this.areaPlayerChunkWatchingManager.movePlayer(player.getWatchedSection().toChunkPos().toLong(), player);
+        player.networkHandler.sendPacket(new ChunkRenderDistanceCenterS2CPacket(player.getWatchedSection().getSectionX(), player.getWatchedSection().getSectionZ()));
     }
 
     @Unique


### PR DESCRIPTION
Explanation of the bug:
Clients (correctly) ignore all chunk unload packets outside view distance. The server was sending the view distance center packet before the chunk unloads. Together, that means unloads were now happening outside the view distance (calculated with the center coming from that packet), which in turn led them to not be unloaded. This fixes issues with sodium (I reckon this is the cause for the 30s loads on some servers) and fixes chunk caching and bugs related to it.